### PR TITLE
CEqual can also get DOMXPathNavigator elements

### DIFF
--- a/XPathFunctions/getCEqual.php
+++ b/XPathFunctions/getCEqual.php
@@ -38,6 +38,7 @@ use lyquidity\XPath2\XPath2NodeIterator;
 use lyquidity\XPath2\Iterator\DocumentOrderNodeIterator;
 use lyquidity\XPath2\FalseValue;
 use lyquidity\XPath2\XPath2Exception;
+use lyquidity\XPath2\DOM\DOMXPathNavigator;
 
 // Make sure any required functions are imported
 require_once "getSEqual.php";
@@ -66,6 +67,12 @@ function getCEqual( $context, $provider, $args )
 	{
 		// There should be two arguments and each argument should be a node iterator
 		// There shold be the same count in each node.
+
+		if ( $args[0] instanceof DOMXPathNavigator )
+			$args[0] = XPath2NodeIterator::Create( $args[0] );
+
+		if ( $args[1] instanceof DOMXPathNavigator )
+			$args[1] = XPath2NodeIterator::Create( $args[1] );
 
 		if ( ! $args[0] instanceof XPath2NodeIterator || ! $args[1] instanceof XPath2NodeIterator )
 		{


### PR DESCRIPTION
This is an error I got with the dfa-5501 assertion in be tax taxonomy

An example of a file that crashes: 
[dfa-5501-crash.xbrl.txt](https://github.com/bseddon/XBRL/files/3606676/dfa-5501-crash.xbrl.txt)

I have no idea if it's correct that `cequal` should receive `DOMXPathNavigator` as a parameter, but this definitely fixes my problem and returns the error I expected.