### PR TITLE
If you have a lot of files to process in a loop, then this array will…

### DIFF
--- a/XBRL-Inline.php
+++ b/XBRL-Inline.php
@@ -603,7 +603,8 @@ class XBRL_Inline
 		{
 			$context->resetEntityLoader();
 			$context->reset();
-			self::$context = null;	
+			self::$context = null;
+            self::$documents = [];
 		}
 
 	}


### PR DESCRIPTION
Example:

```
$data = [[item, item, ...], [item, item, item, ...], ...]; // 300k files

foreach ($data as $files) {
     $docs = \lyquidity\ixbrl\XBRL_Inline::createInstanceDocument('test', $files,'./cache/');

     // another code
}
```

As a result, the script will work as long as there is enough memory, but if we reset self::$documents, then the memory will no longer overflow.

